### PR TITLE
fix: Set default tf binary version to 0.13.2

### DIFF
--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -9,7 +9,7 @@ on:
       tf_version:
         required: false
         type: string
-        default: 1.1.7
+        default: 0.13.2
 
 jobs:
   tf-validate:


### PR DESCRIPTION
* Sets the default Terraform binary version to 0.13.2