### PR TITLE
feat: add helm gha

### DIFF
--- a/.github/workflows/pr-tests-helm.yml
+++ b/.github/workflows/pr-tests-helm.yml
@@ -1,0 +1,116 @@
+name: Helm PR
+
+on:
+  workflow_call:
+    inputs:
+      charts:
+        required: true
+        type: string
+      charts_dir:
+        required: false
+        type: string
+        default: "charts"
+      helm_version:
+        required: false
+        type: string
+        default: "3.2.1"
+      k8s_version:
+        required: false
+        type: string
+        default: "1.24.0"
+
+jobs:
+  helm-lint:
+    name: helm lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dir: ${{fromJson(inputs.charts)}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # v3.0
+        with:
+          version: v${{ inputs.helm_version }}
+
+      - name: Helm Lint
+        working-directory: ${{ inputs.charts_dir }}/${{ matrix.dir }}
+        run: |
+          helm lint --strict . --values values-ci-tests.yaml
+
+  helm-unittest:
+    name: helm unittest
+    runs-on: ubuntu-latest
+    needs: helm-lint
+    strategy:
+      matrix:
+        dir: ${{fromJson(inputs.charts)}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v${{ inputs.helm_version }}
+
+      - name: Helm Unit Test
+        working-directory: ${{ inputs.charts_dir }}/${{ matrix.dir }}
+        run: |
+          helm plugin install https://github.com/vbehar/helm3-unittest
+          helm unittest .
+
+  helm-deprecated-check:
+    name: helm deprecated api check
+    runs-on: ubuntu-latest
+    needs: helm-unittest
+    strategy:
+      matrix:
+        dir: ${{fromJson(inputs.charts)}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # v3.0
+        with:
+          version: v${{ inputs.helm_version }}
+
+      - name: Setup Pluto
+        uses: FairwindsOps/pluto/github-action@0070fa703641a58ec339a9675aa214ba080ad5d3 # v5.10.2
+
+      - name: Check for depricated apis
+        working-directory: ${{ inputs.charts_dir }}/${{ matrix.dir }}
+        run: |
+          helm template . --values values-ci-tests.yaml | pluto detect - -o wide --target-versions k8s=v${{ inputs.k8s_version }}
+
+  helm-install:
+    name: helm install
+    runs-on: ubuntu-latest
+    needs: helm-deprecated-check
+    strategy:
+      matrix:
+        dir: ${{fromJson(inputs.charts)}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # v3.0
+        with:
+          version: v${{ inputs.helm_version }}
+
+      - name: Create kind cluster
+        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d
+        with:
+          node_image: kindest/node:v${{ inputs.k8s_version }}
+
+      - name: Install helm chart
+        working-directory: ${{ inputs.charts_dir }}/${{ matrix.dir }}
+        run: helm install --generate-name --dependency-update --wait --timeout 5m0s . --values values-ci-tests.yaml

--- a/.github/workflows/pr-tests-helm.yml
+++ b/.github/workflows/pr-tests-helm.yml
@@ -28,11 +28,10 @@ jobs:
         dir: ${{fromJson(inputs.charts)}}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
 
-      - name: Install Helm
-        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # v3.0
+      - name: Set up Helm
+        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # renovate: tag=v3.0
         with:
           version: v${{ inputs.helm_version }}
 
@@ -50,11 +49,10 @@ jobs:
         dir: ${{fromJson(inputs.charts)}}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - name: Set up Helm
+        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # renovate: tag=v3.0
         with:
           version: v${{ inputs.helm_version }}
 
@@ -73,16 +71,15 @@ jobs:
         dir: ${{fromJson(inputs.charts)}}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
 
       - name: Set up Helm
-        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # v3.0
+        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # renovate: tag=v3.0
         with:
           version: v${{ inputs.helm_version }}
 
       - name: Setup Pluto
-        uses: FairwindsOps/pluto/github-action@0070fa703641a58ec339a9675aa214ba080ad5d3 # v5.10.2
+        uses: FairwindsOps/pluto/github-action@0070fa703641a58ec339a9675aa214ba080ad5d3 # renovate: tag=v5.10.2
 
       - name: Check for depricated apis
         working-directory: ${{ inputs.charts_dir }}/${{ matrix.dir }}
@@ -98,16 +95,15 @@ jobs:
         dir: ${{fromJson(inputs.charts)}}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
 
       - name: Set up Helm
-        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # v3.0
+        uses: azure/setup-helm@20d2b4f98d41febe2bbca46408499dbb535b6258 # renovate: tag=v3.0
         with:
           version: v${{ inputs.helm_version }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d
+        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d # renovate: tag=v1.3.0
         with:
           node_image: kindest/node:v${{ inputs.k8s_version }}
 

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: "actions/checkout@v2"
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@9b8c94a880e647cdc3e5071e15e20f0fe210b5ce # v3.13.0
+        uses: TriPSs/conventional-changelog-action@9b8c94a880e647cdc3e5071e15e20f0fe210b5ce # renovate: tag=v3.13.0
         with:
           fallback-version: "0.1.0"
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: helm-release
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
 
       - name: Publish Helm charts
-        uses: stefanprodan/helm-gh-pages@b43a8719cc63fdb3aa943cc57359ab19118eab3f # v1.5.0
+        uses: stefanprodan/helm-gh-pages@b43a8719cc63fdb3aa943cc57359ab19118eab3f # renovate: tag=v1.5.0
         with:
           helm_version: ${{ inputs.helm_version }}
           index_dir: "."

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -1,0 +1,63 @@
+name: Helm Release
+
+on:
+  workflow_call:
+    inputs:
+      charts:
+        required: true
+        type: string
+      charts_dir:
+        required: false
+        type: string
+        default: "charts"
+      helm_version:
+        required: false
+        type: string
+        default: "3.2.1"
+
+jobs:
+  helm-release:
+    name: helm release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chart: ${{fromJson(inputs.charts)}}
+
+    steps:
+      - name: Checkout source code
+        uses: "actions/checkout@v2"
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@9b8c94a880e647cdc3e5071e15e20f0fe210b5ce # v3.13.0
+        with:
+          fallback-version: "0.1.0"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: ${{ inputs.charts_dir }}/${{ matrix.chart }}/CHANGELOG.md
+          release-count: "1000" # Keep full changelog
+          skip-ci: "true"
+          skip-commit: "false"
+          skip-on-empty: "false"
+          skip-version-file: "false"
+          tag-prefix: "${{ matrix.chart }}-"
+          version-file: ./${{ inputs.charts_dir }}/${{ matrix.chart }}/Chart.yaml
+          version-path: version
+
+  helm-publish:
+    name: helm publish
+    runs-on: ubuntu-latest
+    needs: helm-release
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@b43a8719cc63fdb3aa943cc57359ab19118eab3f # v1.5.0
+        with:
+          helm_version: ${{ inputs.helm_version }}
+          index_dir: "."
+          linting: "off"
+          target_dir: "archive"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -30,34 +30,23 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Conventional Changelog Action
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@9b8c94a880e647cdc3e5071e15e20f0fe210b5ce # renovate: tag=v3.13.0
+      - name: Helm Release
+        id: release
+        uses: google-github-actions/release-please-action@v3
         with:
-          fallback-version: "0.1.0"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          output-file: ${{ inputs.charts_dir }}/${{ matrix.chart }}/CHANGELOG.md
-          release-count: "1000" # Keep full changelog
-          skip-ci: "true"
-          skip-commit: "false"
-          skip-on-empty: "false"
-          skip-version-file: "false"
-          tag-prefix: "${{ matrix.chart }}-"
-          version-file: ./${{ inputs.charts_dir }}/${{ matrix.chart }}/Chart.yaml
-          version-path: version
-
-  helm-publish:
-    name: helm publish
-    runs-on: ubuntu-latest
-    needs: helm-release
-    steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
+          monorepo-tags: true
+          package-name: ${{ matrix.chart }}
+          path: ${{ inputs.charts_dir }}/${{ matrix.chart }}
+          release-type: helm
+          draft-pull-request: true
 
       - name: Publish Helm charts
-        uses: stefanprodan/helm-gh-pages@b43a8719cc63fdb3aa943cc57359ab19118eab3f # renovate: tag=v1.5.0
+        uses: stefanprodan/helm-gh-pages@b43a8719cc63fdb3aa943cc57359ab19118eab3f # v1.5.0
         with:
           helm_version: ${{ inputs.helm_version }}
+          charts: ${{ inputs.charts_dir }}
           index_dir: "."
           linting: "off"
           target_dir: "archive"
           token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
## Adds re-usable actions for checking and publishing helm with github pages

Pull request example: https://github.com/entur/poc-plattform/actions/runs/2648324062

Merge-to-main example: https://github.com/entur/poc-plattform/actions/runs/2648341499

### New helm release pattern

The helm pulish action now uses `TriPSs/conventional-changelog-action` to generate changelog in each chart folder and pushes a git tag in the repository, this git tag is however not used for the helm publishing anymore.

The github pages bit is a bit different, as the helm packages (artifacts) is instead stored under a folder on the `gh-pages` branch, and the `index.yaml` points to the files in this folder. Making the `index.yaml` more agnostic and opens up the possibility to easily migrate them to another helm repository.

gh-pages example: https://github.com/entur/poc-plattform/tree/gh-pages

### Workflow

- Developer makes changes to chart in PR
- The following tests are run when PR is created/changed:
  - linting
  - unit testing
  - checking k8s apis for deprecation 
  - spin up KIND (kubernetes-in-docker) cluster
  - install helm chart to cluster
- Pull request title is checked for conventional commit formatting
- PR checks are OK and is approved by reviewers
- Merge PR to main as squash commit
- Helm chart version is bumped based on conventional commit
- Change log for the helm chart is updated
- Creates a git tag for the helm chart version
- Helm packages are created and stored under `archive/` in the `gh-pages` branch
- `index.yaml` is updated with the new helm packages
  
### Future possibilities

- Run integration tests inside KIND against the helm chart
