### PR TITLE
fix: use helm 3.8.0 as GCP2 uses that version

### DIFF
--- a/.github/workflows/pr-tests-helm.yml
+++ b/.github/workflows/pr-tests-helm.yml
@@ -13,7 +13,7 @@ on:
       helm_version:
         required: false
         type: string
-        default: "3.2.1"
+        default: "3.8.0"
       k8s_version:
         required: false
         type: string

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -13,7 +13,7 @@ on:
       helm_version:
         required: false
         type: string
-        default: "3.2.1"
+        default: "3.8.0"
 
 jobs:
   helm-release:


### PR DESCRIPTION
We are on feature flag HELM_VERSION_3_8_0 and expect 3.8.0 features to work.