### PR TITLE
feat: terraform validate dir override

### DIFF
--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -39,13 +39,37 @@ jobs:
         working-directory: ${{ matrix.dir }}
         run: |
           terraform init -reconfigure
-          terraform fmt -recursive -check
           terraform validate
+
+  tf-fmt:
+    name: Terraform fmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        dir: ${{fromJson(inputs.module_dirs)}}
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3.0.2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # renovate: tag=v1.4.0
+        with:
+          terraform_version: ${{ inputs.tf_version }}
+
+      - name: Terraform fmt
+        working-directory: ${{ matrix.dir }}
+        run: |
+          terraform init -reconfigure
+          terraform fmt -recursive -check
 
   tf-docs:
     name: Terraform documentation
     runs-on: ubuntu-latest
-    needs: tf-validate
+    needs: [tf-validate, tf-fmt]
     strategy:
       matrix: 
         dir: ${{fromJson(inputs.module_dirs)}}

--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -9,7 +9,7 @@ on:
       validate_dir_override:
         required: false
         type: string
-        default: ${{ inputs.module_dirs }}
+        default: ${{fromJson(inputs.module_dirs)}}
       tf_version:
         required: false
         type: string

--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -6,6 +6,10 @@ on:
       module_dirs: 
         required: true
         type: string
+      validate_dir_override:
+        required: false
+        type: string
+        default: ${{ inputs.module_dirs }}
       tf_version:
         required: false
         type: string
@@ -17,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        dir: ${{fromJson(inputs.module_dirs)}}
+        dir: ${{fromJson(inputs.validate_dir_override)}}
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
Add input for overriding Terraform validate directories. Enables validating using examples instead of validating the module directly. The azurerm provider has required fields, resulting in terraform validate being unable to be run on modules without the provider.

Terraform fmt and validate has been split in two jobs since fmt should always be run on the module, not the example used for validation.

Docs generation also only runs on the module.