### PR TITLE
ci: allow redis to use non encrypted traffic

### DIFF
--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -86,8 +86,8 @@ jobs:
           output_format: cli,sarif
           output_file_path: console,results.sarif
           download_external_modules: true
+          skip_check: CKV_GCP_97
           
-
       - name: Upload Checkov SARIF results
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
Since traffic is in our VPC, we do not bother wasting CPU on TLS negotiation.