### PR TITLE
ci: allow public buckets with no access logs

### DIFF
--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -86,7 +86,7 @@ jobs:
           output_format: cli,sarif
           output_file_path: console,results.sarif
           download_external_modules: true
-          skip_check: CKV_GCP_97
+          skip_check: CKV_GCP_97, CKV_GCP_114
           
       - name: Upload Checkov SARIF results
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -86,7 +86,7 @@ jobs:
           output_format: cli,sarif
           output_file_path: console,results.sarif
           download_external_modules: true
-          skip_check: CKV_GCP_97, CKV_GCP_114
+          skip_check: CKV_GCP_97, CKV_GCP_114, CKV_GCP_62
           
       - name: Upload Checkov SARIF results
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
Entur needs to allow public buckets and no access logs